### PR TITLE
Fix merging array props on creating manifests

### DIFF
--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -1,18 +1,12 @@
 const { promises: fs } = require('fs');
 const path = require('path');
-const { cloneDeep, mergeWith } = require('lodash');
+const { cloneDeep, merge } = require('lodash');
 
 const baseManifest = require('../../app/manifest/_base.json');
 
 const { createTask, composeSeries } = require('./task');
 
 module.exports = createManifestTasks;
-
-function customArrayMerge(objValue, srcValue) {
-  if (Array.isArray(objValue)) {
-    return [...new Set([...objValue ,...srcValue])]
-  }
-}
 
 function createManifestTasks({ browserPlatforms }) {
   // merge base manifest with per-platform manifests
@@ -29,9 +23,7 @@ function createManifestTasks({ browserPlatforms }) {
             `${platform}.json`,
           ),
         );
-        const result = mergeWith(
-          cloneDeep(baseManifest), platformModifications, customArrayMerge
-        );
+        const result = merge(cloneDeep(baseManifest), platformModifications);
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
         await writeJson(result, path.join(dir, 'manifest.json'));

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -1,12 +1,18 @@
 const { promises: fs } = require('fs');
 const path = require('path');
-const { merge, cloneDeep } = require('lodash');
+const { cloneDeep, mergeWith } = require('lodash');
 
 const baseManifest = require('../../app/manifest/_base.json');
 
 const { createTask, composeSeries } = require('./task');
 
 module.exports = createManifestTasks;
+
+function customArrayMerge(objValue, srcValue) {
+  if (Array.isArray(objValue)) {
+    return [...new Set([...objValue ,...srcValue])]
+  }
+}
 
 function createManifestTasks({ browserPlatforms }) {
   // merge base manifest with per-platform manifests
@@ -23,7 +29,9 @@ function createManifestTasks({ browserPlatforms }) {
             `${platform}.json`,
           ),
         );
-        const result = merge(cloneDeep(baseManifest), platformModifications);
+        const result = mergeWith(
+          cloneDeep(baseManifest), platformModifications, customArrayMerge
+        );
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
         await writeJson(result, path.join(dir, 'manifest.json'));

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -30,7 +30,9 @@ function createManifestTasks({ browserPlatforms }) {
           ),
         );
         const result = mergeWith(
-          cloneDeep(baseManifest), platformModifications, customArrayMerge
+          cloneDeep(baseManifest),
+          platformModifications,
+          customArrayMerge
         );
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -1,12 +1,18 @@
 const { promises: fs } = require('fs');
 const path = require('path');
-const { cloneDeep, merge } = require('lodash');
+const { cloneDeep, mergeWith } = require('lodash');
 
 const baseManifest = require('../../app/manifest/_base.json');
 
 const { createTask, composeSeries } = require('./task');
 
 module.exports = createManifestTasks;
+
+function customArrayMerge(objValue, srcValue) {
+  if (Array.isArray(objValue)) {
+    return [...new Set([...objValue ,...srcValue])]
+  }
+}
 
 function createManifestTasks({ browserPlatforms }) {
   // merge base manifest with per-platform manifests
@@ -23,7 +29,9 @@ function createManifestTasks({ browserPlatforms }) {
             `${platform}.json`,
           ),
         );
-        const result = merge(cloneDeep(baseManifest), platformModifications);
+        const result = mergeWith(
+          cloneDeep(baseManifest), platformModifications, customArrayMerge
+        );
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
         await writeJson(result, path.join(dir, 'manifest.json'));


### PR DESCRIPTION
**Fixes**: #3 

**Explanation**:  
I tracked a bug inside Metamasks code that creates browser-specific manifests. The idea here is to have `_base.json` manifest that holds manifest properties that are needed on all browsers and then also have browser-specific manifests such as `chrome.json`. Then, when manifest for specific browser distribution is created, these two manifests are merged into one. The problem occurs when you have array property such as `permissions` in both `_base.json` and `chrome.json` (browser-specific manifest). Below you can find examples of how this merge worked before, and how it works now.

**OLD BEHAVIOUR**
```json
  /* _base.json */
  "permissions": [
    "storage",
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications"
  ]
  
  /* chrome.json */
  "permissions": [
    "chrome-extension://*/*"
  ]
  
  /* results in merged permissions as shown below */
  /* problem is that new permissions from browser specific manifest ovveride base permission /*
  "permissions": [
    "chrome-extension://*/*",  /* notice that storage permission is missing */
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications"
  ]
  
```

**NEW BEHAVIOUR**

```json
  /* _base.json */
  "permissions": [
    "storage",
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications"
  ]
  
  /* chrome.json */
  "permissions": [
    "chrome-extension://*/*"
  ]
  
  /* results in merged permissions as shown below */
  "permissions": [ 
    "storage"
    "unlimitedStorage",
    "clipboardWrite",
    "http://localhost:8545/",
    "https://*.infura.io/",
    "activeTab",
    "webRequest",
    "*://*.eth/",
    "notifications",
    "chrome-extension://*/*"
  ]
  
```